### PR TITLE
8 feature 4 joinview tournament

### DIFF
--- a/src/main/java/useCases/joinTournament/JoinTournamentIB.java
+++ b/src/main/java/useCases/joinTournament/JoinTournamentIB.java
@@ -1,0 +1,5 @@
+package useCases.joinTournament;
+
+public interface JoinTournamentIB {
+    JoinTournamentOD joinBracket(JoinTournamentID input);
+}

--- a/src/main/java/useCases/joinTournament/JoinTournamentID.java
+++ b/src/main/java/useCases/joinTournament/JoinTournamentID.java
@@ -1,38 +1,17 @@
 package useCases.joinTournament;
 
-import entities.BracketRepo;
-import entities.User;
-
 public class JoinTournamentID {
     private String invite;
-    private User currUser;
-    private BracketRepo repo;
 
-    public JoinTournamentID(String invite, User currUser){
+    public JoinTournamentID(String invite) {
         this.invite = invite;
-        this.currUser = currUser;
     }
+
     String getInvite() {
         return invite;
     }
 
     void setInvite(String invite) {
         this.invite = invite;
-    }
-
-    User getCurrUser() {
-        return currUser;
-    }
-
-    void setCurrUser(User currUser) {
-        this.currUser = currUser;
-    }
-
-    public BracketRepo getRepo() {
-        return repo;
-    }
-
-    public void setRepo(BracketRepo repo) {
-        this.repo = repo;
     }
 }

--- a/src/main/java/useCases/joinTournament/JoinTournamentID.java
+++ b/src/main/java/useCases/joinTournament/JoinTournamentID.java
@@ -1,0 +1,38 @@
+package useCases.joinTournament;
+
+import entities.BracketRepo;
+import entities.User;
+
+public class JoinTournamentID {
+    private String invite;
+    private User currUser;
+    private BracketRepo repo;
+
+    public JoinTournamentID(String invite, User currUser){
+        this.invite = invite;
+        this.currUser = currUser;
+    }
+    String getInvite() {
+        return invite;
+    }
+
+    void setInvite(String invite) {
+        this.invite = invite;
+    }
+
+    User getCurrUser() {
+        return currUser;
+    }
+
+    void setCurrUser(User currUser) {
+        this.currUser = currUser;
+    }
+
+    public BracketRepo getRepo() {
+        return repo;
+    }
+
+    public void setRepo(BracketRepo repo) {
+        this.repo = repo;
+    }
+}

--- a/src/main/java/useCases/joinTournament/JoinTournamentOB.java
+++ b/src/main/java/useCases/joinTournament/JoinTournamentOB.java
@@ -1,0 +1,7 @@
+package useCases.joinTournament;
+
+public interface JoinTournamentOB {
+    JoinTournamentOD prepareSuccessView(JoinTournamentOD outputData);
+
+    JoinTournamentOD prepareFailView(String error);
+}

--- a/src/main/java/useCases/joinTournament/JoinTournamentOD.java
+++ b/src/main/java/useCases/joinTournament/JoinTournamentOD.java
@@ -1,0 +1,27 @@
+package useCases.joinTournament;
+
+public class JoinTournamentOD {
+    int tournamentID;
+    String role;
+
+    public JoinTournamentOD(int tournamentID, String role){
+        this.tournamentID = tournamentID;
+        this.role = role;
+    }
+
+    public int getTournamentID() {
+        return tournamentID;
+    }
+
+    public void setTournamentID(int tournamentID) {
+        this.tournamentID = tournamentID;
+    }
+
+    public String getRole() {
+        return role;
+    }
+
+    public void setRole(String role) {
+        this.role = role;
+    }
+}

--- a/src/main/java/useCases/joinTournament/JoinTournamentUC.java
+++ b/src/main/java/useCases/joinTournament/JoinTournamentUC.java
@@ -1,23 +1,28 @@
 package useCases.joinTournament;
 
+import entities.AccountRepo;
 import entities.BracketRepo;
 import entities.User;
 
 public class JoinTournamentUC implements JoinTournamentIB{
     final JoinTournamentOB outputBound;
+    private final BracketRepo bracketRepo;
+    private final AccountRepo accountRepo;
+    private User currUser;
 
-    public JoinTournamentUC(JoinTournamentOB outputBound){
+    public JoinTournamentUC(JoinTournamentOB outputBound, BracketRepo bracketRepo, AccountRepo accountRepo, String currUser){
         this.outputBound = outputBound;
+        this.bracketRepo = bracketRepo;
+        this.accountRepo = accountRepo;
+        this.currUser = accountRepo.getUser(currUser);
     }
 
     public JoinTournamentOD joinBracket(JoinTournamentID input){
         String role = input.getInvite().substring(0, 2);
         String idAndName = input.getInvite().substring(2);
         int tournamentID = Integer.parseInt(idAndName.split("(?<=\\d)(?=\\D)")[0]);
-        User currUser = input.getCurrUser();
-        BracketRepo repo = input.getRepo();
 
-        if (!repo.getBrackets().containsKey(tournamentID)){
+        if (!bracketRepo.getBrackets().containsKey(tournamentID)){
             return outputBound.prepareFailView("Tournament does not exist.");
         }
         else if (currUser.getAllTournaments().contains(tournamentID)){
@@ -35,7 +40,7 @@ public class JoinTournamentUC implements JoinTournamentIB{
         }
         else {
             currUser.setBracketRole(tournamentID, "Observer");
-            repo.getBracket(tournamentID).addReferee(currUser);
+            bracketRepo.getBracket(tournamentID).addReferee(currUser);
             output = new JoinTournamentOD(tournamentID, "Observer");
         }
         return outputBound.prepareSuccessView(output);

--- a/src/main/java/useCases/joinTournament/JoinTournamentUC.java
+++ b/src/main/java/useCases/joinTournament/JoinTournamentUC.java
@@ -1,0 +1,43 @@
+package useCases.joinTournament;
+
+import entities.BracketRepo;
+import entities.User;
+
+public class JoinTournamentUC implements JoinTournamentIB{
+    final JoinTournamentOB outputBound;
+
+    public JoinTournamentUC(JoinTournamentOB outputBound){
+        this.outputBound = outputBound;
+    }
+
+    public JoinTournamentOD joinBracket(JoinTournamentID input){
+        String role = input.getInvite().substring(0, 2);
+        String idAndName = input.getInvite().substring(2);
+        int tournamentID = Integer.parseInt(idAndName.split("(?<=\\d)(?=\\D)")[0]);
+        User currUser = input.getCurrUser();
+        BracketRepo repo = input.getRepo();
+
+        if (!repo.getBrackets().containsKey(tournamentID)){
+            return outputBound.prepareFailView("Tournament does not exist.");
+        }
+        else if (currUser.getAllTournaments().contains(tournamentID)){
+            return outputBound.prepareFailView("You have already joined this tournament.");
+        }
+        else if (!role.equals("PL") && !role.equals("OB")){
+            return outputBound.prepareFailView("Role does not exist within tournament.");
+        }
+        currUser.setCurrentTournament(tournamentID);
+        currUser.addTournament(tournamentID);
+        JoinTournamentOD output;
+        if (role.equals("PL")){
+            currUser.setBracketRole(tournamentID, "Player");
+            output = new JoinTournamentOD(tournamentID, "Player");
+        }
+        else {
+            currUser.setBracketRole(tournamentID, "Observer");
+            repo.getBracket(tournamentID).addReferee(currUser);
+            output = new JoinTournamentOD(tournamentID, "Observer");
+        }
+        return outputBound.prepareSuccessView(output);
+    }
+}

--- a/src/main/java/useCases/viewTournament/ViewTournamentIB.java
+++ b/src/main/java/useCases/viewTournament/ViewTournamentIB.java
@@ -1,0 +1,5 @@
+package useCases.viewTournament;
+
+public interface ViewTournamentIB {
+    ViewTournamentOD viewBracket(ViewTournamentID input);
+}

--- a/src/main/java/useCases/viewTournament/ViewTournamentID.java
+++ b/src/main/java/useCases/viewTournament/ViewTournamentID.java
@@ -1,14 +1,10 @@
 package useCases.viewTournament;
 
-import entities.User;
-
 public class ViewTournamentID {
     private int tournamentID;
-    private User currUser;
 
-    public ViewTournamentID(int tournamentID, User currUser){
+    public ViewTournamentID(int tournamentID){
         this.tournamentID = tournamentID;
-        this.currUser = currUser;
     }
     int getTournamentID() {
         return tournamentID;
@@ -18,11 +14,4 @@ public class ViewTournamentID {
         this.tournamentID = tournamentID;
     }
 
-    User getCurrUser() {
-        return currUser;
-    }
-
-    void setCurrUser(User currUser) {
-        this.currUser = currUser;
-    }
 }

--- a/src/main/java/useCases/viewTournament/ViewTournamentID.java
+++ b/src/main/java/useCases/viewTournament/ViewTournamentID.java
@@ -1,0 +1,28 @@
+package useCases.viewTournament;
+
+import entities.User;
+
+public class ViewTournamentID {
+    private int tournamentID;
+    private User currUser;
+
+    public ViewTournamentID(int tournamentID, User currUser){
+        this.tournamentID = tournamentID;
+        this.currUser = currUser;
+    }
+    int getTournamentID() {
+        return tournamentID;
+    }
+
+    void setTournamentID(int tournamentID) {
+        this.tournamentID = tournamentID;
+    }
+
+    User getCurrUser() {
+        return currUser;
+    }
+
+    void setCurrUser(User currUser) {
+        this.currUser = currUser;
+    }
+}

--- a/src/main/java/useCases/viewTournament/ViewTournamentOB.java
+++ b/src/main/java/useCases/viewTournament/ViewTournamentOB.java
@@ -1,0 +1,7 @@
+package useCases.viewTournament;
+
+public interface ViewTournamentOB {
+    ViewTournamentOD prepareSuccessView(ViewTournamentOD outputData);
+
+    ViewTournamentOD prepareFailView(String error);
+}

--- a/src/main/java/useCases/viewTournament/ViewTournamentOD.java
+++ b/src/main/java/useCases/viewTournament/ViewTournamentOD.java
@@ -1,0 +1,27 @@
+package useCases.viewTournament;
+
+public class ViewTournamentOD {
+    int tournamentID;
+    String role;
+
+    public ViewTournamentOD(int tournamentID, String role){
+        this.tournamentID = tournamentID;
+        this.role = role;
+    }
+
+    public int getTournamentID() {
+        return tournamentID;
+    }
+
+    public void setTournamentID(int tournamentID) {
+        this.tournamentID = tournamentID;
+    }
+
+    public String getRole() {
+        return role;
+    }
+
+    public void setRole(String role) {
+        this.role = role;
+    }
+}

--- a/src/main/java/useCases/viewTournament/ViewTournamentUC.java
+++ b/src/main/java/useCases/viewTournament/ViewTournamentUC.java
@@ -1,17 +1,21 @@
 package useCases.viewTournament;
 
+import entities.AccountRepo;
 import entities.User;
 
 public class ViewTournamentUC implements ViewTournamentIB {
     final ViewTournamentOB outputBound;
+    private final AccountRepo accountRepo;
+    private User currUser;
 
-    public ViewTournamentUC(ViewTournamentOB outputBound){
+    public ViewTournamentUC(ViewTournamentOB outputBound, AccountRepo accountRepo, String currUser){
         this.outputBound = outputBound;
+        this.accountRepo = accountRepo;
+        this.currUser = accountRepo.getUser(currUser);
     }
 
     public ViewTournamentOD viewBracket(ViewTournamentID input){
         int tournamentID = input.getTournamentID();
-        User currUser = input.getCurrUser();
 
         if (!currUser.getAllTournaments().contains(tournamentID)){
             return outputBound.prepareFailView("You have not joined this tournament yet.");

--- a/src/main/java/useCases/viewTournament/ViewTournamentUC.java
+++ b/src/main/java/useCases/viewTournament/ViewTournamentUC.java
@@ -1,0 +1,25 @@
+package useCases.viewTournament;
+
+import entities.User;
+
+public class ViewTournamentUC implements ViewTournamentIB {
+    final ViewTournamentOB outputBound;
+
+    public ViewTournamentUC(ViewTournamentOB outputBound){
+        this.outputBound = outputBound;
+    }
+
+    public ViewTournamentOD viewBracket(ViewTournamentID input){
+        int tournamentID = input.getTournamentID();
+        User currUser = input.getCurrUser();
+
+        if (!currUser.getAllTournaments().contains(tournamentID)){
+            return outputBound.prepareFailView("You have not joined this tournament yet.");
+        }
+
+        String role = currUser.getBracketRole(tournamentID);
+        ViewTournamentOD output = new ViewTournamentOD(tournamentID, role);
+
+        return outputBound.prepareSuccessView(output);
+    }
+}


### PR DESCRIPTION
This is a pull request for the feature(s) relating to allowing a user to join a new tournament or view a tournament they have previously joined. This was designed using the principles of clean architecture. 

### JoinTournament
This pull request contains the following new classes in the use case layer: JoinTournamentUC (the use case interactor), JoinTournamentID (the input data/request model), JoinTournamentOD (output data/response model), JoinTournamentIB (input boundary), and JoinTournamentOB (output boundary).

The input data takes the invite code for the tournament. The interactor implements the input boundary and does the following: provided all necessary conditions are met, the user becomes either an observer or player of the tournament corresponding to the invite code, and the user is brought to the main tournament view page. The output data packages and brings data out to the presenter.

### ViewTournament
This pull request contains the following new classes in the use case layer: ViewTournamentUC (the use case interactor), ViewTournamentID (the input data/request model), ViewTournamentOD (output data/response model), ViewTournamentIB (input boundary), and ViewTournamentOB (output boundary). 

The input data takes the tournamentID. The interactor implements the input boundary and does the following: provided all necessary conditions are met, the user is brought to the main tournament view page. The output data packages and brings data out to the presenter.